### PR TITLE
topPageの各種修正

### DIFF
--- a/rihlar_front/Utils/Core/CircleMap.swift
+++ b/rihlar_front/Utils/Core/CircleMap.swift
@@ -69,10 +69,12 @@ struct CircleMap: UIViewRepresentable {
             }
           }
 
-        // Always show track polyline
-        let coords = playerPosition.track
-        if coords.count >= 2 {
-            uiView.addOverlay(MKPolyline(coordinates: coords, count: coords.count))
+//         ─────────── 歩いた軌跡を描画（進行中 or コレクションモードのときだけ） ───────────
+        if gameStatus == .inProgress || gameType == .system {
+            let coords = playerPosition.track
+            if coords.count >= 2 {
+                uiView.addOverlay(MKPolyline(coordinates: coords, count: coords.count))
+            }
         }
 
         // Show circles if in progress or in collection mode

--- a/rihlar_front/Utils/Core/CircleMap.swift
+++ b/rihlar_front/Utils/Core/CircleMap.swift
@@ -160,13 +160,16 @@ struct CircleMap: UIViewRepresentable {
 
 
     private func color(for group: String) -> UIColor {
+        if group == "Self" {
+            return .blue
+        }
+        // それ以外は順位で色分け
         switch group {
         case "Top1": return .orange
         case "Top2": return .red
         case "Top3": return .green
         case "Other": return .white
-        case "Self": return .blue
-        default: return .black
+        default:     return .black
         }
     }
 


### PR DESCRIPTION
・歩いた後の線の表示修正
特定の行動をすると意図していないタイミングで線が表示されていた
例）初期ロードのTopPage(線なし) → コレクションモードに移動(線あり) → 再び対戦モードに移動(線出現)
のように対戦モードでゲームが始まっていないのに線が出て来てしまっていた

・自分が上位になると円の色が被ってしまうところを修正
自分のランキングが上位になると円の色が自分の色と上位の色で被ってしまいチカチカしていたので自分の色である青色を優先させた